### PR TITLE
Feat: Add global error boundary

### DIFF
--- a/apps/web/src/app/club-list/_suspense/ClubInfoSearchSuspense/index.tsx
+++ b/apps/web/src/app/club-list/_suspense/ClubInfoSearchSuspense/index.tsx
@@ -9,8 +9,8 @@ export const ClubInfoSearchSuspense = withSuspense(
 
       return <ClubInfoSearchClient initialData={data} />;
     } catch (error) {
-      console.error(error);
-      return <span>에러 발생!!</span>;
+      console.error('ClubInfoSearchSuspense', error);
+      throw new Error(`동아리 정보 검색에 실패했어요`);
     }
   },
   { fallback: <span>로딩중...</span> },

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,24 @@
+'use client'; // NOTE: Error boundaries must be Client Components
+
+/**
+ * web 서비스의 global error 를 핸들링하는 Error boundary
+ * @see https://nextjs.org/docs/app/getting-started/error-handling
+ */
+const GlobalError = ({ error }: { error: Error & { digest?: string } }) => {
+  return (
+    // NOTE: global-error must include html and body tags
+    <html lang="ko">
+      <body>
+        <h2>{error.message}</h2>
+        <button
+          onClick={() => {
+            window.location.reload();
+          }}>
+          다시 시도하기
+        </button>
+      </body>
+    </html>
+  );
+};
+
+export default GlobalError;


### PR DESCRIPTION
### 작업 내용

1. web 서비스에서 에러 throw 시, global error boundary 에 잡히도록 합니다.
2. 에러 페이지에서 `다시 시도하기` 버튼을 누르면 페이지가 리로드 됩니다.

### 테스트 방법

http://localhost:3000/club-list

middleware.ts 에서 유저 타입 변경해서 테스트할 수 있습니다.
`const userType = USER_TYPE.준회원;`

https://github.com/user-attachments/assets/6439a7c3-9998-4107-b84d-64be1db935da

개발 환경에서는 빨간색 에러가 뜨는데, 프로덕션 환경에서는 에러 페이지만 표시됩니다.